### PR TITLE
Add links and youtube videos to talk agendas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Now with NextJS!
 
 ## Wishlist
 
-In no particular order:
-
-- Post-event view of page with downloads / YouTube links for talks.
+Add something here if you want it worked on!
 
 ## Getting Started
 

--- a/src/components/EventAgenda/EventAgenda.module.scss
+++ b/src/components/EventAgenda/EventAgenda.module.scss
@@ -77,4 +77,21 @@
   &__speakerTitle {
     color: grey;
   }
+
+  &__youtubeEmbed {
+    margin-bottom: 20px;
+  }
+
+  &__linksHeading {
+    font-size: 1rem;
+    font-weight: bold;
+  }
+
+  &__links {
+    padding-left: 1rem;
+
+    li {
+      list-style: none;
+    }
+  }
 }

--- a/src/components/EventAgenda/EventAgenda.tsx
+++ b/src/components/EventAgenda/EventAgenda.tsx
@@ -12,6 +12,7 @@ import styles from './EventAgenda.module.scss';
 import DefaultProfileImage from './default-profile.svg';
 import Link from 'next/link';
 import cn from 'classnames';
+import YoutubeEmbed from '../YoutubeEmbed';
 
 type EventAgendaItemProps = EventAgendaItemData;
 
@@ -26,7 +27,7 @@ const EventAgendaItem = ({ time, description }: EventAgendaItemProps) => (
 
 type EventAgendaTalkProps = Omit<EventAgendaTalkData, 'speaker'> & { speaker: SpeakerContent };
 
-const EventAgendaTalk = ({ time, title, description, speaker }: EventAgendaTalkProps) => (
+const EventAgendaTalk = ({ time, title, description, speaker, youtubeVideoId }: EventAgendaTalkProps) => (
   <Row className={styles.eventAgenda__entry}>
     <Col className={styles.eventAgenda__time} md={2}>
       {time}
@@ -53,6 +54,7 @@ const EventAgendaTalk = ({ time, title, description, speaker }: EventAgendaTalkP
         </div>
       </div>
       <p>{description}</p>
+      {youtubeVideoId && <YoutubeEmbed videoId={youtubeVideoId} />}
     </Col>
   </Row>
 );

--- a/src/components/EventAgenda/EventAgenda.tsx
+++ b/src/components/EventAgenda/EventAgenda.tsx
@@ -27,7 +27,7 @@ const EventAgendaItem = ({ time, description }: EventAgendaItemProps) => (
 
 type EventAgendaTalkProps = Omit<EventAgendaTalkData, 'speaker'> & { speaker: SpeakerContent };
 
-const EventAgendaTalk = ({ time, title, description, speaker, youtubeVideoId }: EventAgendaTalkProps) => (
+const EventAgendaTalk = ({ time, title, description, speaker, youtubeVideoId, links }: EventAgendaTalkProps) => (
   <Row className={styles.eventAgenda__entry}>
     <Col className={styles.eventAgenda__time} md={2}>
       {time}
@@ -54,7 +54,25 @@ const EventAgendaTalk = ({ time, title, description, speaker, youtubeVideoId }: 
         </div>
       </div>
       <p>{description}</p>
-      {youtubeVideoId && <YoutubeEmbed videoId={youtubeVideoId} />}
+      {youtubeVideoId && (
+        <div className={styles.eventAgenda__youtubeEmbed}>
+          <YoutubeEmbed videoId={youtubeVideoId} />
+        </div>
+      )}
+      {links && links.length && (
+        <>
+          <h4 className={styles.eventAgenda__linksHeading}>Links</h4>
+          <ul className={styles.eventAgenda__links}>
+            {links.map(({ text, url }) => (
+              <li key={url}>
+                <a href={url} rel='noreferrer' target='_blank'>
+                  {text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </Col>
   </Row>
 );

--- a/src/components/EventInfo/EventInfo.tsx
+++ b/src/components/EventInfo/EventInfo.tsx
@@ -12,7 +12,8 @@ type EventInfoProps = Omit<EventContent, 'date'> & {
   dateTimestamp: number;
 };
 
-const formatMapLink = (address: string): string => `http://maps.apple.com/?address=${encodeURIComponent(address)},&t=m`;
+const formatMapLink = (address: string): string =>
+  `https://maps.apple.com/?address=${encodeURIComponent(address)},&t=m`;
 
 const EventInfo = ({ dateTimestamp, title, duration, venue: { name, address } }: EventInfoProps) => {
   const date = new Date(dateTimestamp);

--- a/src/components/YoutubeEmbed/YoutubeEmbed.module.scss
+++ b/src/components/YoutubeEmbed/YoutubeEmbed.module.scss
@@ -1,0 +1,21 @@
+@use '/src/styles/theme/settings/colors';
+@use '/src/styles/theme/settings/media';
+@use '/src/styles/theme/settings/vars';
+
+@import '/node_modules/bootstrap/scss/functions';
+@import '/node_modules/bootstrap/scss/variables';
+
+.youtubeEmbed {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+
+  iframe {
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+}

--- a/src/components/YoutubeEmbed/YoutubeEmbed.tsx
+++ b/src/components/YoutubeEmbed/YoutubeEmbed.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from './YoutubeEmbed.module.scss';
+
+type YoutubeEmbedProps = {
+  videoId: string;
+};
+
+const YoutubeEmbed = ({ videoId }: YoutubeEmbedProps) => (
+  <div className={styles.youtubeEmbed}>
+    <iframe
+      width='853'
+      height='480'
+      src={`https://www.youtube.com/embed/${videoId}`}
+      frameBorder='0'
+      allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+      allowFullScreen
+      title='Embedded youtube'
+    />
+  </div>
+);
+
+export default YoutubeEmbed;

--- a/src/components/YoutubeEmbed/index.ts
+++ b/src/components/YoutubeEmbed/index.ts
@@ -1,0 +1,3 @@
+import YoutubeEmbed from './YoutubeEmbed';
+
+export default YoutubeEmbed;

--- a/src/content.types.ts
+++ b/src/content.types.ts
@@ -39,6 +39,7 @@ export type EventAgendaTalk = {
   speaker: string;
   title: string;
   description: string;
+  youtubeVideoId?: string;
 };
 
 export type EventAgendaItem = {

--- a/src/content.types.ts
+++ b/src/content.types.ts
@@ -40,6 +40,10 @@ export type EventAgendaTalk = {
   title: string;
   description: string;
   youtubeVideoId?: string;
+  links?: {
+    text: string;
+    url: string;
+  }[];
 };
 
 export type EventAgendaItem = {


### PR DESCRIPTION
Can now add a single YouTube embed and multiple links to event talks for the purposes of sharing videos + slides after an event is complete.