### PR TITLE
Fixing duration for SoftServe event

### DIFF
--- a/src/data/events/2025-04-softserve-sitecore-usergroup.yml
+++ b/src/data/events/2025-04-softserve-sitecore-usergroup.yml
@@ -10,7 +10,7 @@ intro: >
   <p>See below for the full agenda and to RSVP your place.</p>
   <p><b><u>Note</u></b> For security reasons you must RSVP for this event in advance to get in the door.</p>
 date: !!timestamp 2025-04-30 17:30:00+00:00
-duration: 25
+duration: 150
 dateConfirmed: true
 showOnlineRsvp: true
 showEventImage: false


### PR DESCRIPTION
Changing "25min" duration for this event to "150min" (2.5hrs) This should fix the iCal (etc) files having a very short duration when downloaded.